### PR TITLE
fix: do not fail on multiline commit messages

### DIFF
--- a/aserehe/check.py
+++ b/aserehe/check.py
@@ -36,4 +36,4 @@ def _check_single(message):
 def check():
     repo = Repo(".")
     for commit in repo.iter_commits():
-        _check_single(commit.message)
+        _check_single(commit.summary)


### PR DESCRIPTION
Currently only commit summary (first line) is parsed and checked
(that is given by the `$` char in the `_REGEX` const).
If the commit contains multiple lines the regex will not match as it
expects only a single line because `.` char matches any character except
a newline (see https://docs.python.org/3/library/re.html).
