### PR TITLE
refactor!: rename check to _check_git

### DIFF
--- a/aserehe/__main__.py
+++ b/aserehe/__main__.py
@@ -1,8 +1,8 @@
-from aserehe.check import check
+from aserehe.check import _check_git
 
 
 def main():
-    check()
+    _check_git()
 
 
 if __name__ == "__main__":

--- a/aserehe/check.py
+++ b/aserehe/check.py
@@ -33,7 +33,7 @@ def _check_single(message):
         raise InvalidCommitType(f"Invalid commit type: {commit_type}")
 
 
-def check():
+def _check_git():
     repo = Repo(".")
     for commit in repo.iter_commits():
         _check_single(commit.summary)


### PR DESCRIPTION
The function is not intended to be used outside aserehe.
The public API of aserehe should be CLI only.

BREAKING CHANGE: `aserehe.check.check` is not in public API anymore.
Renamed to `aserehe.check._check_git`.
