### PR TITLE
refactor: yield parsed commits

### DIFF
--- a/aserehe/_check.py
+++ b/aserehe/_check.py
@@ -97,7 +97,7 @@ def _check_git_commit(commit: Commit) -> ConventionalCommit:
     return ConventionalCommit.from_message(message)
 
 
-def _check_git() -> None:
+def _check_git() -> Iterator[ConventionalCommit]:
     repo = Repo(".")
     for commit in repo.iter_commits():
-        _check_git_commit(commit)
+        yield _check_git_commit(commit)

--- a/aserehe/_check.py
+++ b/aserehe/_check.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Self
+from typing import Iterator, Self
 
 from git.objects import Commit
 from git.repo import Repo


### PR DESCRIPTION
This makes the behaviour of _check_git and _check_git_commit functions
consistent.
