### PR TITLE
chore: update uv.lock with python version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.11, <4.0.0"
 
 [[package]]
 name = "aserehe"


### PR DESCRIPTION
Fixes 7b6b258
