### PR TITLE
refactor: simplify breaking change footer detection

### DIFF
--- a/src/aserehe/_check.py
+++ b/src/aserehe/_check.py
@@ -75,21 +75,20 @@ class ConventionalCommit:
                 " a blank line."
             )
 
-        breaking_changes = _extract_breaking_change_footer_values(message)
+        breaking_changes = _breaking_change_footer_present(message)
 
         return cls(
             type=summary_conv_commit.type,
-            breaking=summary_conv_commit.breaking | bool(breaking_changes),
+            breaking=summary_conv_commit.breaking | breaking_changes,
         )
 
 
-def _extract_breaking_change_footer_values(message: str) -> list[str]:
+def _breaking_change_footer_present(message: str) -> bool:
     _, *footer_section = re.split(_FOOTER_TOKEN_REGEX, message)
-    breaking_changes = []
-    for token, value in zip(footer_section[::2], footer_section[1::2], strict=True):
+    for token, _ in zip(footer_section[::2], footer_section[1::2], strict=True):
         if re.match(_BREAKING_CHANGE_FOOTER_TOKEN_REGEX, token):
-            breaking_changes.append(str(value))
-    return breaking_changes
+            return True
+    return False
 
 
 def parse_git_commit(commit: Commit) -> ConventionalCommit:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -4,7 +4,7 @@ from aserehe._check import (
     ConventionalCommit,
     InvalidCommitMessageError,
     InvalidCommitTypeError,
-    _extract_breaking_change_footer_values,
+    _breaking_change_footer_present,
 )
 
 
@@ -46,13 +46,4 @@ Lorem ipsum dolor: this is not a footer but a paragraph in a breaking change foo
 This is still a part of the third breaking change.
 X: This is not a breaking change footer.
 """
-    breaking_changes = _extract_breaking_change_footer_values(message)
-    assert breaking_changes == [
-        "this is a first breaking change",
-        "A second breaking change ends with a newline.\n",
-        """A third breaking change contains a multiline paragraph below.
-
-Lorem ipsum dolor: this is not a footer but a paragraph in a breaking change footer.
-
-This is still a part of the third breaking change.""",
-    ]
+    assert _breaking_change_footer_present(message)


### PR DESCRIPTION
Parsing of the exact breaking changes is not needed until changelog
command is implemented.
It is not certain that `aserehe` will implement changelog at all.
