### PR TITLE
refactor: delete deprecated flag parameter

### DIFF
--- a/src/aserehe/__main__.py
+++ b/src/aserehe/__main__.py
@@ -25,7 +25,6 @@ def version(
         bool,
         typer.Option(
             "--next",
-            is_flag=True,
             help="Whether to print the next semantic version instead of the current",
         ),
     ] = False,


### PR DESCRIPTION
Typer treats boolean options as flags by default.
