### PR TITLE
refactor!: do not use __main__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 [project.scripts]
-aserehe = "aserehe.__main__:app"
+aserehe = "aserehe._cli:app"
 
 [project.urls]
 repository = "https://github.com/lukany/aserehe"

--- a/src/aserehe/_cli.py
+++ b/src/aserehe/_cli.py
@@ -52,7 +52,3 @@ def version(
     else:
         version_to_print = get_current_version(repo)
     typer.echo(version_to_print)
-
-
-if __name__ == "__main__":
-    app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from git.repo import Repo
 from typer.testing import CliRunner
 
-from aserehe.__main__ import app
+from aserehe._cli import app
 
 runner = CliRunner()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,23 @@ def test_stdin(valid_message):
     )
     assert result.exit_code == 0
 
+def test_check_commits(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo = Repo.init()
+
+    # Valid commits should pass
+    repo.index.commit("feat: add feature")
+    repo.index.commit("fix: fix bug")
+    repo.index.commit("docs: update readme")
+
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 0
+
+    # Invalid commit should fail
+    repo.index.commit("invalid commit message")
+    result = runner.invoke(app, ["check"])
+    assert result.exit_code == 1
+
 
 def test_version(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
BREAKING-CHANGE: `aserehe` can't be executed as `python -m aserehe`
anymore but only as `aserehe` (defined as script in `pyproject.toml`).
